### PR TITLE
fix: non-existen obj on guildmember

### DIFF
--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -4,7 +4,7 @@ const client = require('../index');
 const guildSchema = require('../schemas/guild-schema');
 
 client.on('guildMemberAdd', async (guildmember) => {
-	const data = await guildSchema.findById(guildmember.guild.id);
+	const data = await guildSchema.findById(guildmember.id);
 	if (!data) return;
 	const welcomechannel = guildmember.guild.channels.cache.get(
 		data.welcomeChannelId

--- a/src/events/guildMemberRemove.js
+++ b/src/events/guildMemberRemove.js
@@ -2,7 +2,7 @@ const client = require('../index');
 const guildSchema = require('../schemas/guild-schema');
 
 client.on('guildMemberRemove', async (guildmember) => {
-	const data = await guildSchema.findById(guildmember.guild.id);
+	const data = await guildSchema.findById(guildmember.id);
 	if (!data) return;
 	const welcomechannel = guildmember.guild.channels.cache.get(
 		data.welcomeChannelId


### PR DESCRIPTION
# Description

I'm not sure about the intended behavior of `/simulatejoin` but at least now it doesn't produce errors that result in the Bot just shutting down...

The object `guildmember` in `'guildMemberAdd` & `'guildMemberRemove'` looks like this:
```
User {
  id: '796517722984808498',
  bot: false,
  system: false,
  flags: UserFlags { bitfield: 0 },
  username: 'Mohammed A. Gomaa',
  discriminator: '1155',
  avatar: 'e0b0b9ea197b0d6a7c269c1e4b7e01c2',
  accentColor: undefined
}
```

i.e. it doesn't contain `guild` object as in the old code `guildmember.guild.id` but just straight forward `guildmember.id`.

Fixes #36 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Now there's no error BUT again I'm not sure about if this is the intended behavior of the command `/simulatejoin`
also I made sure that there's no other command which calls this file in particular, i.e. I searched for a command using the same `client.emit('guildMemberAdd', interaction.user);` but `simjoin.js` is the only one.

# Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have restored `.env.template`
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes - Run `npm run format`
- [ ] Any dependent changes have been merged and published in downstream modules
