### PR TITLE
Help command

### DIFF
--- a/src/slashCommands/general/help.js
+++ b/src/slashCommands/general/help.js
@@ -1,0 +1,92 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { MessageEmbed } = require('discord.js');
+const { glob } = require('glob');
+const { promisify } = require('util');
+const { readdirSync, statSync } = require ('fs');
+
+module.exports = {
+	...new SlashCommandBuilder()
+		.setName('help')
+		.setDescription('Displays command info'),
+
+	/**
+	 *
+	 * @param {Client} client
+	 * @param {CommandInteraction} interaction
+	 * @param {String[]} args
+	 */
+
+	run:  async (client, interaction) => {
+		//NOTE Getting arrayOfDirs - List of dir names / command topics
+	const path = `${process.cwd()}/src/slashCommands`;
+	const arrayOfDirs = readdirSync(path).filter(function (file) {
+		return statSync(path+'/'+file).isDirectory();
+	});
+
+		
+	var  topics=[];
+	for(let dir of arrayOfDirs) {  //NOTE For every topic do..
+		
+		let text= "";
+		
+		//NOTE Get arrayOfSlashCommands for specific topic
+		const globPromise = promisify(glob);
+		const slashCommands = await globPromise(`${process.cwd()}/src/slashCommands/${dir}/*.js`);
+		const arrayOfSlashCommands = [];
+		slashCommands.map((value) => {
+			const file = require(value);
+			if (!file?.name) return;
+			client.slashCommands.set(file.name, file);
+			if (['MESSAGE', 'USER'].includes(file.type)) delete file.description;
+			arrayOfSlashCommands.push(file);
+		});
+
+		//NOTE Add every command name and description to text value.
+		arrayOfSlashCommands.forEach(command => {	
+			text += `/${command.name} - ${command.description}\n`
+		});
+
+		topics.push({
+			name: enchancedTopic(dir), //NOTE Enchant topic name
+			value: `${text}`,
+			inline: true,
+		});
+
+		if(topics.length%3==2) //NOTE - To make only 2 rows - every third is empty
+		topics.push(	{
+			name: '\u200b',
+			value: '\u200b',
+			inline: false,
+		});
+	};
+
+	//NOTE make embed with fields
+	const embed = new MessageEmbed()
+				.setTitle(`Help`)
+				.setColor('ORANGE')
+				.setFooter({ text: `Called By: ${interaction.user.tag}` })
+				.setTimestamp()
+				.setDescription(`List of commands`)
+				.addFields(topics);
+
+			interaction.reply({ embeds: [embed] });
+	},
+};
+
+//NOTE Enchant topic name
+function enchancedTopic(name) {
+	switch (name) {
+		case "moderation":
+			return "Admin ⚒️"
+		case "general":
+			return "Deneral 📖"
+		case "debugging":
+			return "Debugging ℹ"
+		case "siege":
+			return "Siege 🔫"
+		case "fun":
+			return "Fun 🎉"
+		default:
+			return name
+	}
+}


### PR DESCRIPTION
# Description
From https://github.com/KieranRobson/Clarence-Bot/issues/9 issue

![obrázok](https://user-images.githubusercontent.com/63195508/199269969-9443d0fa-0029-4f14-9979-fbb7093c424b.png)
Added one /help command. Takes directory names as topic names (they can be modified). Also fetching all available commands from the topic directory and displaying their name and description.