### PR TITLE
feat: Add ISO code to weather command

### DIFF
--- a/src/slashCommands/fun/weather.js
+++ b/src/slashCommands/fun/weather.js
@@ -10,12 +10,14 @@ module.exports = {
 		.addStringOption((option) =>
 			option.setName('city').setDescription('Name of City').setRequired(true)
 		),
+
 	/**
 	 *
 	 * @param {Client} client
 	 * @param {CommandInteraction} interaction
 	 * @param {String[]} args
 	 */
+
 	run: async (client, interaction) => {
 		const APIKey = process.env.OPEN_WEATHERS_API;
 		const cityInputted = interaction.options.getString('city');
@@ -30,20 +32,19 @@ module.exports = {
 			if (err != null) {
 				interaction.reply({ content: `${err}` });
 			} else {
+				const ISO = JSONObj.sys.country;
+
 				const embed = new MessageEmbed()
 					.setColor('ORANGE')
-					.setFooter({
-						text: `Speed of Wind : ${parseInt(
-							JSONObj.wind.speed
-						)} m/s · Humidity: ${JSONObj.main.humidity}% · Pressure: ${
-							JSONObj.main.pressure
-						}hPa `,
-					})
-					.setTitle(`Weather of ${cityInputted}`)
+					.setTitle(`Weather of ${cityInputted}, ${ISO}`)
 					.setDescription(
 						`${parseInt(JSONObj.main.temp)} °C ${ChangeFirstLetterToUpperCase(
 							JSONObj.weather[0].description
-						)}`
+						)}
+						\r\n
+						Speed of Wind : ${parseInt(JSONObj.wind.speed)} m/s 
+						Humidity: ${JSONObj.main.humidity}% 
+						Pressure: ${JSONObj.main.pressure}hPa`
 					)
 					.setThumbnail(
 						`http://openweathermap.org/img/wn/${JSONObj.weather[0].icon}@2x.png`


### PR DESCRIPTION
# Description

Add the iso code to the weather command

<img width="286" alt="image" src="https://user-images.githubusercontent.com/32241933/203793506-945253dd-2bb5-452b-ba0d-2567fb64a5ed.png">

Fixes #87 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Using the official clarence bot and running `/Weather`

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have restored `.env.template`
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes - Run `yarn run format`
- [ ] Any dependent changes have been merged and published in downstream modules
